### PR TITLE
fix(person): require DOB or approximate age on save and prevent parti…

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/person/PersonFacadeEjb.java
@@ -751,6 +751,25 @@ public class PersonFacadeEjb extends AbstractBaseEjb<Person, PersonDto, PersonIn
 		/*if (source.getApproximateAge() == null || source.getApproximateAgeType() == null) {
 			throw new ValidationRuntimeException(I18nProperties.getValidationError(Validations.approximateAgeAndType));
 		}*/
+
+		boolean hasBirthYear = source.getBirthdateYYYY() != null;
+		boolean hasBirthMonth = source.getBirthdateMM() != null;
+		boolean hasBirthDay = source.getBirthdateDD() != null;
+
+		boolean hasAnyBirthDatePart = hasBirthYear || hasBirthMonth || hasBirthDay;
+		boolean hasCompleteBirthDate = hasBirthYear && hasBirthMonth && hasBirthDay;
+
+		boolean hasApproximateAge = source.getApproximateAge() != null;
+		boolean hasApproximateAgeType = source.getApproximateAgeType() != null;
+
+		if (hasAnyBirthDatePart && !hasCompleteBirthDate) {
+			throw new ValidationRuntimeException("Date of Birth is incomplete.");
+		}
+
+		if (!hasCompleteBirthDate && !(hasApproximateAge && hasApproximateAgeType)) {
+			throw new ValidationRuntimeException(
+					I18nProperties.getValidationError(Validations.approximateAgeAndType));
+		}
 		if (source.getPersonContactDetails()
 			.stream()
 			.filter(cd -> cd.isPrimaryContact() && cd.getPersonContactDetailType() == PersonContactDetailType.PHONE)


### PR DESCRIPTION
fix(person): enforce DOB or approximate age validation in person save

- Added validation to ensure either full date of birth or approximate age + age type is provided
- Prevent partial DOB entries (year/month/day incomplete)
- Removed reliance on case-level validation for age checks
- Aligns validation behavior across person, symptoms, and case workflows
- Fixes issue where symptoms save triggered unexpected age validation errors